### PR TITLE
Fix #4 Add max-bytes parameter for wrap-request-body middleware

### DIFF
--- a/src/middleware/request-body.lisp
+++ b/src/middleware/request-body.lisp
@@ -4,31 +4,58 @@
   (:use :cl)
   (:import-from :tiny-routes.request
                 #:raw-body
+                #:content-length
                 #:request-append)
   (:import-from :tiny-routes.middleware.builder
                 #:wrap-request-mapper)
+  (:import-from :tiny-routes.response
+                #:payload-too-large)
   (:export #:read-stream-to-string
            #:input-stream-mapper
+           #:payload-too-large-handler
            #:wrap-request-body))
 
 (in-package :tiny-routes.middleware.request-body)
 
-;; TODO: Add support for a max number of bytes the server is willing
-;; to read before sending back a Payload Too Large response.
-(defun read-stream-to-string (input-stream)
-  "Read INPUT-STREAM entirely and return the contents as a string."
-  (when input-stream)
-  (with-output-to-string (output-stream)
-    (let ((buf (make-array 4096 :element-type (stream-element-type input-stream))))
-      (loop for pos = (read-sequence buf input-stream)
-            while (plusp pos)
-            do (write-sequence buf output-stream :end pos)))))
+(defun read-stream-to-string (input-stream content-length)
+  "Read INPUT-STREAM return contents as a string.
 
-(defun wrap-request-body (handler &key (input-stream-mapper #'read-stream-to-string))
+If CONTENT-LENGTH is non-nil, it must be a positive integer
+representing the maximum number of bytes to read from INPUT-STREAM."
+  (with-output-to-string (output-stream)
+    (if content-length
+        (let* ((buffer (make-array content-length :element-type (stream-element-type input-stream)))
+               (position (read-sequence buffer input-stream)))
+          (write-sequence buffer output-stream :end position))
+        (let ((buf (make-array 4096 :element-type (stream-element-type input-stream))))
+          (loop for pos = (read-sequence buf input-stream)
+                while (plusp pos)
+                do (write-sequence buf output-stream :end pos))))))
+
+(defun payload-too-large-handler (request)
+  "Return a response representing a payload too large to be handled."
+  (declare (ignore request))
+  (payload-too-large))
+
+(defun wrap-request-body (handler &key max-bytes
+                                    (input-stream-mapper #'read-stream-to-string)
+                                    (payload-too-large-handler #'payload-too-large-handler))
   "Wrap HANDLER such that the result of applying INPUT-STREAM-MAPPER to
-the request body is made available to the request via `:request-body'."
-  (wrap-request-mapper
-   handler
-   (lambda (request)
-     (let ((body (funcall input-stream-mapper (raw-body request))))
-       (request-append request :request-body body)))))
+the request body is made available to the request via `:request-body'.
+
+If MAX-BYTES is non-nil, it must be a positive integer representing the
+maximum number of bytes to read from INPUT-STREAM.
+
+PAYLOAD-TOO-LARGE-HANDLER is a `handler' called if MAX-BYTES is non nil
+and the content-length of string is greater than MAX-BYTES."
+  (lambda (request)
+    (let ((content-length (content-length request)))
+      (cond ((null content-length)
+             (funcall handler request))
+            ;; handle if request is too large
+            ((and (typep max-bytes '(integer 1))
+                  (> content-length max-bytes))
+             (funcall payload-too-large-handler request))
+            (t
+             (let ((body (funcall input-stream-mapper (raw-body request) content-length)))
+               (funcall handler (request-append request :request-body body))))))))

--- a/t/tiny-routes-test.lisp
+++ b/t/tiny-routes-test.lisp
@@ -86,14 +86,19 @@
 
 (test middleware-test1
   (with-input-from-string (in "Sample request body stream")
-    (let* ((request (make-request :request-method :get :request-uri "/users/jeko" :raw-body in)))
+    (let* ((request (make-request :request-method :get :request-uri "/users/jeko" :raw-body in
+                                  :content-length 26)))
       (is (eq in (raw-body request)))
       (is (string= "Sample request body stream"
                    (request-get (response-body (funcall (wrap-request-body #'echo-handler) request))
                                 :request-body)))
+      (is (equalp '(413 nil nil)
+                  (funcall (wrap-request-body #'echo-handler :max-bytes 2) request)))
       (is (equalp '(:user-id "jeko")
-                  (request-get (response-body (funcall (wrap-request-matches-path-template #'echo-handler "/users/:user-id")
-                                                       request))
+                  (request-get (response-body
+                                (funcall
+                                 (wrap-request-matches-path-template #'echo-handler "/users/:user-id")
+                                 request))
                                :path-parameters))))))
 
 (def-suite* routes :in tiny-routes)


### PR DESCRIPTION
Add optional `max-bytes` parameter to `wrap-request-body` representing the maximum number of bytes to read from the raw body input stream.